### PR TITLE
removed abandoned patchwork/utf8 package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "ausi/slug-generator": "^1.1",
     "contao/core-bundle": "^4.9",
     "doctrine/dbal": "^2.11 || ^3.0",
-    "patchwork/utf8": "^1.2",
+    "symfony/polyfill-mbstring": "^1.0",
     "symfony/config": "^4.4 || ^5.1",
     "symfony/dependency-injection": "^4.4 || ^5.1",
     "symfony/http-kernel": "^4.4 || ^5.1"

--- a/src/ContentElement/ContentNavigationElement.php
+++ b/src/ContentElement/ContentNavigationElement.php
@@ -16,7 +16,7 @@ use Contao\FrontendTemplate;
 use Contao\Input;
 use Contao\StringUtil;
 use Hofff\Contao\ContentNavigation\Navigation\ContentNavigationBuilder;
-use Patchwork\Utf8;
+use Symfony\Polyfill\Mbstring\Mbstring;
 
 use function assert;
 use function count;
@@ -54,7 +54,7 @@ final class ContentNavigationElement extends ContentElement
     {
         if (defined('TL_MODE') && TL_MODE === 'BE') {
             $template           = new BackendTemplate('be_wildcard');
-            $template->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['CTE'][$this->type][0]) . ' ###';
+            $template->wildcard = '### ' . Mbstring::mb_strtoupper($GLOBALS['TL_LANG']['CTE'][$this->type][0], 'UTF-8') . ' ###';
             $template->title    = $this->headline;
             $template->id       = $this->id;
             $template->link     = $GLOBALS['TL_LANG']['CTE'][$this->type][0];

--- a/src/EventListener/Dca/ContentDcaListener.php
+++ b/src/EventListener/Dca/ContentDcaListener.php
@@ -12,7 +12,7 @@ use Contao\LayoutModel;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Hofff\Contao\ContentNavigation\Navigation\Query\ArticlePageQuery;
-use Patchwork\Utf8;
+use Symfony\Polyfill\Mbstring\Mbstring;
 
 use function assert;
 use function html_entity_decode;
@@ -133,7 +133,7 @@ final class ContentDcaListener
             $cssId = 'id-' . $cssId;
         }
 
-        $value[0] = Utf8::strtolower(trim($cssId, '-'));
+        $value[0] = Mbstring::mb_strtolower(trim($cssId, '-'), 'UTF-8');
 
         return $value;
     }


### PR DESCRIPTION
The patchwork/utf8 package is abandoned. This fix removes the dependency and replaces it with the symfony/polyfill-mbstring package.