### PR TITLE
Update ContentNavigationBuilder.php

### DIFF
--- a/src/Navigation/ContentNavigationBuilder.php
+++ b/src/Navigation/ContentNavigationBuilder.php
@@ -65,6 +65,11 @@ final class ContentNavigationBuilder
 
         do {
             $item = current($result);
+            
+            if ($item === false) {
+                continue;
+            }
+            
             $page = $this->relatedPages->ofItem($item);
 
             if ($page === null) {


### PR DESCRIPTION
Fixes PHP warning if `current($result)` returns false inside `ofItem()` method:
![image](https://github.com/hofff/contao-content-navigation/assets/2776658/9bfd0b6f-31f3-4c38-98ce-3e1e6ebfebe0)
