### PR TITLE
Add optional short title for the content navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ This extension was previously published as *ce_navigation* and maintained by Tri
 
 ## Requirements
 
- - Contao: ^4.9
- - PHP: ^7.1 || ^8.0
+ - Contao: ^5.3
+ - PHP: ^8.1
  
 ## Usage
 
  - Create a content element "Table of contents" and define the source
  - Active option "Include in table of contents" for each content element
+ - Optionally define a short title, which is used in the navigation and for the generated CSS ID
+   instead of the headline
 
 Now you get an content navigation for each element marked as included and having a headline.
 

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
   "require": {
     "php": "^8.1",
     "ausi/slug-generator": "^1.1",
-    "contao/core-bundle": "^4.13 || ^5.3",
+    "contao/core-bundle": "^5.3",
     "doctrine/dbal": "^3.8",
-    "symfony/config": "^5.4 || ^6.4 || ^7.4",
-    "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.4",
-    "symfony/http-foundation": "^5.4 || ^6.4 || ^7.4",
-    "symfony/http-kernel": "^5.4 || ^6.4 || ^7.4",
-    "symfony/routing": "^5.4 || ^6.4 || ^7.4",
-    "symfony/string": "^5.4 || ^6.4 || ^7.4",
-    "symfony/translation-contracts": "^1.1 || ^2.0 || ^3.0"
+    "symfony/config": "^6.4 || ^7.4",
+    "symfony/dependency-injection": "^6.4 || ^7.4",
+    "symfony/http-foundation": "^6.4 || ^7.4",
+    "symfony/http-kernel": "^6.4 || ^7.4",
+    "symfony/routing": "^6.4 || ^7.4",
+    "symfony/string": "^6.4 || ^7.4",
+    "symfony/translation-contracts": "^3.0"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.1",

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,11 +23,6 @@
                 <referencedMethod name="Contao\PageModel::getFrontendUrl"/>
             </errorLevel>
         </DeprecatedMethod>
-        <UndefinedMagicPropertyFetch>
-            <errorLevel type="suppress">
-                <referencedProperty name="Contao\DataContainer::$activeRecord"/>
-            </errorLevel>
-        </UndefinedMagicPropertyFetch>
     </issueHandlers>
 
     <universalObjectCrates>

--- a/src/EventListener/Dca/ContentDcaListener.php
+++ b/src/EventListener/Dca/ContentDcaListener.php
@@ -9,17 +9,17 @@ use Contao\Backend;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
+use Contao\DC_Table;
+use Contao\Input;
 use Contao\LayoutModel;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Hofff\Contao\ContentNavigation\Navigation\Query\ArticlePageQuery;
 use Symfony\Component\String\UnicodeString;
 
-use function assert;
 use function html_entity_decode;
 use function is_array;
 use function is_numeric;
-use function is_object;
 use function sprintf;
 use function trim;
 
@@ -36,7 +36,7 @@ final class ContentDcaListener
 
     /** @SuppressWarnings(PHPMD.Superglobals) */
     #[AsCallback('tl_content', 'config.onload')]
-    public function adjustPalettes(): void
+    public function adjustPalettes(DataContainer|null $dataContainer = null): void
     {
         if (
             ! isset($GLOBALS['TL_DCA']['tl_content']['palettes'])
@@ -48,6 +48,13 @@ final class ContentDcaListener
         $manipulator = PaletteManipulator::create()
             ->addField('hofff_toc_include', 'cssID', PaletteManipulator::POSITION_BEFORE);
 
+        // The short title is added to the palette instead of being registered as a subpalette, because
+        // Contao renders subpalettes in a container of their own, which prevents the field from being
+        // displayed next to the checkbox.
+        if ($this->isIncludedInNavigation($dataContainer)) {
+            $manipulator->addField('hofff_toc_title', 'hofff_toc_include', PaletteManipulator::POSITION_AFTER);
+        }
+
         foreach ($GLOBALS['TL_DCA']['tl_content']['palettes'] as $name => $config) {
             if (is_array($config)) {
                 continue;
@@ -55,6 +62,30 @@ final class ContentDcaListener
 
             $manipulator->applyToPalette($name, 'tl_content');
         }
+    }
+
+    /** Determine if the content element being edited is included in the content navigation. */
+    private function isIncludedInNavigation(DataContainer|null $dataContainer): bool
+    {
+        if ($dataContainer === null) {
+            return false;
+        }
+
+        $act = Input::get('act');
+
+        // The palette is generated once for all records when editing multiple elements, so the field
+        // has to be offered independently of the value of a single record.
+        if ($act === 'editAll' || $act === 'overrideAll') {
+            return true;
+        }
+
+        if ($act !== 'edit') {
+            return false;
+        }
+
+        $currentRecord = $dataContainer->getCurrentRecord();
+
+        return (bool) ($currentRecord['hofff_toc_include'] ?? false);
     }
 
     /**
@@ -67,16 +98,18 @@ final class ContentDcaListener
     #[AsCallback('tl_content', 'fields.hofff_toc_source.options')]
     public function sourceOptions(DataContainer $dataContainer): array
     {
+        $currentRecord = $dataContainer->getCurrentRecord();
+
         if (
             $GLOBALS['TL_DCA']['tl_content']['config']['ptable'] !== 'tl_article'
-            || $dataContainer->activeRecord === null
+            || $currentRecord === null
         ) {
             return [];
         }
 
         return [
             (string) $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_column'] => $this->activeSections(
-                (int) $dataContainer->activeRecord->pid,
+                (int) $currentRecord['pid'],
             ),
             (string) $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_page']   => $this->pageArticles(
                 (int) $dataContainer->id,
@@ -94,23 +127,33 @@ final class ContentDcaListener
     {
         $value = StringUtil::deserialize($value, true);
 
+        // DC_Table::getActiveRecord() is used instead of DataContainer::getCurrentRecord(), because it
+        // also contains the values submitted in the running save cycle. The headline and the checkbox
+        // are saved before the CSS ID, while the record itself is not updated until all save callbacks
+        // have been run.
+        $activeRecord = $dataContainer instanceof DC_Table ? $dataContainer->getActiveRecord() : null;
+
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (
-            ! $dataContainer?->activeRecord?->hofff_toc_include
+            ! ($activeRecord['hofff_toc_include'] ?? null)
             || $value[0]
         ) {
             return $value;
         }
 
-        /** @psalm-suppress PossiblyNullPropertyFetch */
-        assert(is_object($dataContainer->activeRecord));
+        // The CSS ID is generated from what is being displayed in the navigation, hence the short
+        // title takes precedence over the headline here as well.
+        $cssId = trim((string) ($activeRecord['hofff_toc_title'] ?? ''));
 
-        $headline = StringUtil::deserialize($dataContainer->activeRecord->headline, true);
-        if (! $headline['value']) {
+        if ($cssId === '') {
+            $headline = StringUtil::deserialize($activeRecord['headline'] ?? null, true);
+            $cssId    = trim((string) ($headline['value'] ?? ''));
+        }
+
+        if ($cssId === '') {
             return $value;
         }
 
-        $cssId = $headline['value'];
         $cssId = html_entity_decode($cssId, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet']);
         $cssId = StringUtil::stripInsertTags($cssId);
         $cssId = $this->cssIdGenerator->generate($cssId);

--- a/src/Navigation/ContentNavigationBuilder.php
+++ b/src/Navigation/ContentNavigationBuilder.php
@@ -15,6 +15,7 @@ use function is_object;
 use function next;
 use function prev;
 use function substr;
+use function trim;
 
 final class ContentNavigationBuilder
 {
@@ -143,7 +144,7 @@ final class ContentNavigationBuilder
                 $arrItem = array_merge(
                     (array) $item,
                     [
-                        'title' => $headline['value'],
+                        'title' => $this->navigationTitle($item, $headline),
                         'href'  => $pageUrl . '#' . $cssId[0],
                     ],
                 );
@@ -152,6 +153,25 @@ final class ContentNavigationBuilder
         } while (next($result));
 
         return $items;
+    }
+
+    /**
+     * Determine the title being rendered in the navigation.
+     *
+     * The optional short title takes precedence over the headline of the content element.
+     *
+     * @param object              $item     The content element.
+     * @param array<string,mixed> $headline The deserialized headline of the content element.
+     */
+    private function navigationTitle(object $item, array $headline): string
+    {
+        $title = trim((string) ($item->hofff_toc_title ?? ''));
+
+        if ($title !== '') {
+            return $title;
+        }
+
+        return (string) $headline['value'];
     }
 
     /**

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -54,8 +54,17 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_include'] = [
     'inputType' => 'checkbox',
     'exclude'   => true,
     'filter'    => true,
-    'eval'      => ['tl_class' => 'clr w50'],
+    'eval'      => ['submitOnChange' => true, 'tl_class' => 'clr w50 cbx m12'],
     'sql'       => 'char(1) NOT NULL default \'\'',
+];
+
+$GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_title'] = [
+    'label'     => &$GLOBALS['TL_LANG']['tl_content']['hofff_toc_title'],
+    'inputType' => 'text',
+    'exclude'   => true,
+    'search'    => true,
+    'eval'      => ['maxlength' => 255, 'tl_class' => 'w50'],
+    'sql'       => 'varchar(255) NOT NULL default \'\'',
 ];
 
 $GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_force_request_uri'] = [

--- a/src/Resources/contao/languages/de/tl_content.php
+++ b/src/Resources/contao/languages/de/tl_content.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_content']['hofff_toc_min_level']         = ['Start Level
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_max_level']         = ['Stopp Level', 'Bei dieser Überschriftenebene aufhören (inklusive).'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_include']           = ['In Inhaltsnavigation aufnehmen', 'Element wird in der Inhaltsnavigation aufgenommen, soweit eine Überschrift definiert ist. Falls keine CSS-ID vorhanden ist, wird diese automatisch generiert.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_force_request_uri'] = ['Request URI verwenden', 'Immer aktuelle Request URI anstelle der verknüpften Seite verwenden.'];
+$GLOBALS['TL_LANG']['tl_content']['hofff_toc_title']             = ['Kurztitel für die Inhaltsnavigation', 'Optionale Kurzfassung, die anstelle der Überschrift in der Inhaltsnavigation ausgegeben wird. Bleibt das Feld leer, wird die Überschrift verwendet.'];
 
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_column'] = 'Artikel in Spalte';
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_page']   = 'Artikel in Seite';

--- a/src/Resources/contao/languages/en/tl_content.php
+++ b/src/Resources/contao/languages/en/tl_content.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_content']['hofff_toc_min_level']         = ['Start level
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_max_level']         = ['Stop level', 'Stop at this headline level (inclusive).'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_include']           = ['Include in content navigation', 'Element will be included in the content navigation if a headline is defined. If there is no CSS ID, it will be generated automatically.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_force_request_uri'] = ['Force request uri', 'Use current request uri as base link instead of related page'];
+$GLOBALS['TL_LANG']['tl_content']['hofff_toc_title']             = ['Short title for the content navigation', 'Optional short version being rendered in the content navigation instead of the headline. If left empty, the headline is used.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_column']     = 'Article in column';
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_page']       = 'Article in page';
 


### PR DESCRIPTION
Adds an optional short title for content elements, which is rendered in the content navigation instead of the headline.

Headlines are written for the page, not for a table of contents, so they are frequently too long to read well in the navigation. The new field hofff_toc_title is offered whenever Include in content navigation is checked. If it is left empty, the headline is used exactly as before, so existing installations are unaffected.

<img width="1192" height="488" alt="image" src="https://github.com/user-attachments/assets/2624f3c6-943e-4b21-802d-4e4251dbc73d" />


Changes:

- New field hofff_toc_title (varchar(255)), shown next to the hofff_toc_include checkbox
- ContentNavigationBuilder prefers the short title over the headline when building an item
- Labels added for de and en
- README requirements updated (they still claimed Contao ^4.9 / PHP ^7.1 || ^8.0, which no longer matched composer.json)

The element is still only picked up when a headline and a CSS ID are present — the short title only replaces what is displayed, it does not change which elements end up in the navigation. Heading levels continue to be derived from the headline unit.

Why the field is not a subpalette:

The obvious implementation would be a subpalette on hofff_toc_include. Contao renders subpalettes into a container of their own (DC_Table creates a separate sub_* widget group), which is block level and therefore always starts a new row. The field could not be placed next to the checkbox that way.

Instead the field is appended to the palette from the existing config.onload callback when the checkbox is set, so both are regular palette fields in the same float row (clr w50 cbx m12 + w50). submitOnChange on the checkbox triggers the reload that makes the field appear.

One consequence worth noting: when editing multiple records the palette is generated once for all of them, so the field is offered unconditionally in editAll / overrideAll mode.

Breaking change: Contao ^5.3

contao/core-bundle is raised from ^4.13 || ^5.3 to ^5.3, as 4.13 has reached end of life. The Symfony constraints are narrowed accordingly — Contao 5.3 already requires symfony/* ^6.4 and symfony/translation-contracts ^3.0, so the ^5.4 and ^1.1 || ^2.0 branches were not installable regardless.