### PR TITLE
Add a foldable variant of the navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ You can define the source for the table of content structure depending where the
  - Article: Column, Specific article or parent element (current article)
  - News: Parent element (news)
  - Event: Parent element (event)
+
+## Foldable navigation
+
+Select the template `hofff_content_nav_foldable` in the *Navigation template* field to make the sub
+levels foldable. Every entry having children gets a toggle button, which can be operated with mouse
+and keyboard and carries the according `aria-expanded`, `aria-controls` and `aria-label` attributes.
+
+The navigation is rendered expanded and is collapsed by the script afterwards, so that all entries
+remain reachable without JavaScript. When the page is opened with an anchor, the ancestors of the
+linked entry are expanded and the entry is marked with the class `toc-current`. Each entry carries
+its anchor in `data-toc-id`.
+
+The required assets are registered automatically for templates whose name starts with
+`hofff_content_nav_foldable`, so custom copies keeping that prefix are covered as well. Templates
+named differently have to add `bundles/hofffcontentnavigation/foldable.js` and `foldable.css`
+themselves.
+
+The shipped stylesheet only indents the sub levels and draws the caret. Styling beyond that is left
+to the theme, the following hooks are available:
+
+| | |
+|---|---|
+| `.toc-toggle` | the toggle button, `aria-expanded` reflects the state |
+| `.toc-has-children` | entry having sub items |
+| `.toc-expanded` | entry whose sub items are currently visible |
+| `.toc-current` | entry the current anchor points to |
  - FAQ: Parent element (FAQ entry)
  
 ## Customization

--- a/src/ContentElement/ContentNavigationElement.php
+++ b/src/ContentElement/ContentNavigationElement.php
@@ -23,6 +23,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function count;
 use function is_numeric;
+use function str_starts_with;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -31,6 +32,12 @@ use function is_numeric;
 #[AsContentElement('hofff_content_navigation', 'links', 'ce_hofff_content_navigation')]
 final class ContentNavigationElement extends AbstractContentElementController
 {
+    private const DEFAULT_NAVIGATION_TEMPLATE = 'hofff_content_nav_default';
+
+    private const FOLDABLE_NAVIGATION_TEMPLATE = 'hofff_content_nav_foldable';
+
+    private const ASSET_PATH = 'bundles/hofffcontentnavigation';
+
     public function __construct(
         private readonly ContentNavigationBuilder $navigationBuilder,
         private readonly RouterInterface $router,
@@ -72,7 +79,11 @@ final class ContentNavigationElement extends AbstractContentElementController
             );
         }
 
-        $template->items          = $this->parseItems($items);
+        $navigationTemplate = (string) $model->hofff_toc_nav_tpl ?: self::DEFAULT_NAVIGATION_TEMPLATE;
+
+        $this->registerAssets($navigationTemplate);
+
+        $template->items          = $this->parseItems($items, $navigationTemplate);
         $template->request        = Environment::get('indexFreeRequest');
         $template->skipId         = 'skipNavigation' . $model->id;
         $template->skipNavigation = StringUtil::specialchars(
@@ -83,7 +94,7 @@ final class ContentNavigationElement extends AbstractContentElementController
     }
 
     /** @param list<array<string,mixed>> $items */
-    private function parseItems(array $items, int $level = 1): string
+    private function parseItems(array $items, string $templateName, int $level = 1): string
     {
         if (! count($items)) {
             return '';
@@ -91,7 +102,7 @@ final class ContentNavigationElement extends AbstractContentElementController
 
         foreach ($items as &$item) {
             if (isset($item['subitems'])) {
-                $item['subitems'] = $this->parseItems($item['subitems'], $level + 1);
+                $item['subitems'] = $this->parseItems($item['subitems'], $templateName, $level + 1);
             }
 
             $item['class'] = '';
@@ -100,10 +111,33 @@ final class ContentNavigationElement extends AbstractContentElementController
         $items[0]['class']                 = 'first';
         $items[count($items) - 1]['class'] = 'last';
 
-        $tpl = new FrontendTemplate('hofff_content_nav_default');
-        $tpl->setData(['items' => $items, 'level' => $level]);
+        $tpl = new FrontendTemplate($templateName);
+        $tpl->setData([
+            'items'         => $items,
+            'level'         => $level,
+            'expandLabel'   => $this->translator->trans('MSC.hofff_toc_expand', [], 'contao_default'),
+            'collapseLabel' => $this->translator->trans('MSC.hofff_toc_collapse', [], 'contao_default'),
+        ]);
 
         return $tpl->parse();
+    }
+
+    /**
+     * Register the assets required to fold the navigation.
+     *
+     * Templates derived from the foldable one keep its prefix, so that customized copies are covered
+     * as well. Templates named differently have to take care of the assets themselves.
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    private function registerAssets(string $templateName): void
+    {
+        if (! str_starts_with($templateName, self::FOLDABLE_NAVIGATION_TEMPLATE)) {
+            return;
+        }
+
+        $GLOBALS['TL_JAVASCRIPT'][self::FOLDABLE_NAVIGATION_TEMPLATE] = self::ASSET_PATH . '/foldable.js|static';
+        $GLOBALS['TL_CSS'][self::FOLDABLE_NAVIGATION_TEMPLATE]        = self::ASSET_PATH . '/foldable.css|static';
     }
 
     private function getBackendView(ContentModel $model, Template $frontendTemplate): Response

--- a/src/EventListener/Dca/ContentDcaListener.php
+++ b/src/EventListener/Dca/ContentDcaListener.php
@@ -58,6 +58,17 @@ final class ContentDcaListener
     }
 
     /**
+     * Return the templates being available for rendering the navigation itself.
+     *
+     * @return array<string|int,string>
+     */
+    #[AsCallback('tl_content', 'fields.hofff_toc_nav_tpl.options')]
+    public function navigationTemplateOptions(): array
+    {
+        return Backend::getTemplateGroup('hofff_content_nav_');
+    }
+
+    /**
      * Return all content elements as array.
      *
      * @return array<string, array<string|int,string>>

--- a/src/Navigation/ContentNavigationBuilder.php
+++ b/src/Navigation/ContentNavigationBuilder.php
@@ -143,8 +143,9 @@ final class ContentNavigationBuilder
                 $arrItem = array_merge(
                     (array) $item,
                     [
-                        'title' => $headline['value'],
-                        'href'  => $pageUrl . '#' . $cssId[0],
+                        'title'  => $headline['value'],
+                        'anchor' => $cssId[0],
+                        'href'   => $pageUrl . '#' . $cssId[0],
                     ],
                 );
                 $items[] = $arrItem;

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  */
 $GLOBALS['TL_DCA']['tl_content']['palettes']['hofff_content_navigation'] = '{type_legend},type,headline'
     . ';{toc_legend},hofff_toc_source,hofff_toc_min_level,hofff_toc_max_level,hofff_toc_force_request_uri'
-    . ';{template_legend:hide},customTpl'
+    . ';{template_legend:hide},hofff_toc_nav_tpl,customTpl'
     . ';{protected_legend:hide},protected'
     . ';{expert_legend:hide},guests,cssID,space'
     . ';{invisible_legend:hide},invisible,start,stop';
@@ -47,6 +47,14 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_max_level'] = [
     'options'   => ['1', '2', '3', '4', '5', '6'],
     'eval'      => ['tl_class' => 'w50'],
     'sql'       => 'int(1) UNSIGNED NOT NULL default 6',
+];
+
+$GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_nav_tpl'] = [
+    'label'     => &$GLOBALS['TL_LANG']['tl_content']['hofff_toc_nav_tpl'],
+    'inputType' => 'select',
+    'exclude'   => true,
+    'eval'      => ['includeBlankOption' => true, 'chosen' => true, 'tl_class' => 'w50'],
+    'sql'       => 'varchar(64) NOT NULL default \'\'',
 ];
 
 $GLOBALS['TL_DCA']['tl_content']['fields']['hofff_toc_include'] = [

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -13,3 +13,6 @@ $GLOBALS['TL_LANG']['CTE']['hofff_content_navigation'] = [
     'Inhaltsnavigation',
     'Erzeugt über alle Inhaltselementen mit Überschrift und CSS ID eine Navigation.',
 ];
+
+$GLOBALS['TL_LANG']['MSC']['hofff_toc_expand']   = 'Unterpunkte von „%s“ anzeigen';
+$GLOBALS['TL_LANG']['MSC']['hofff_toc_collapse'] = 'Unterpunkte von „%s“ ausblenden';

--- a/src/Resources/contao/languages/de/tl_content.php
+++ b/src/Resources/contao/languages/de/tl_content.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_content']['hofff_toc_min_level']         = ['Start Level
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_max_level']         = ['Stopp Level', 'Bei dieser Überschriftenebene aufhören (inklusive).'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_include']           = ['In Inhaltsnavigation aufnehmen', 'Element wird in der Inhaltsnavigation aufgenommen, soweit eine Überschrift definiert ist. Falls keine CSS-ID vorhanden ist, wird diese automatisch generiert.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_force_request_uri'] = ['Request URI verwenden', 'Immer aktuelle Request URI anstelle der verknüpften Seite verwenden.'];
+$GLOBALS['TL_LANG']['tl_content']['hofff_toc_nav_tpl']           = ['Navigations-Template', 'Template für die Navigationsliste. Mit "hofff_content_nav_foldable" lassen sich Unterebenen auf- und zuklappen.'];
 
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_column'] = 'Artikel in Spalte';
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_page']   = 'Artikel in Seite';

--- a/src/Resources/contao/languages/en/default.php
+++ b/src/Resources/contao/languages/en/default.php
@@ -13,3 +13,6 @@ $GLOBALS['TL_LANG']['CTE']['hofff_content_navigation'] = [
     'Table of contents',
     'Creates a navigation over all content elements with heading and CSS ID.',
 ];
+
+$GLOBALS['TL_LANG']['MSC']['hofff_toc_expand']   = 'Show sub items of “%s”';
+$GLOBALS['TL_LANG']['MSC']['hofff_toc_collapse'] = 'Hide sub items of “%s”';

--- a/src/Resources/contao/languages/en/tl_content.php
+++ b/src/Resources/contao/languages/en/tl_content.php
@@ -16,6 +16,7 @@ $GLOBALS['TL_LANG']['tl_content']['hofff_toc_min_level']         = ['Start level
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_max_level']         = ['Stop level', 'Stop at this headline level (inclusive).'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_include']           = ['Include in content navigation', 'Element will be included in the content navigation if a headline is defined. If there is no CSS ID, it will be generated automatically.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_force_request_uri'] = ['Force request uri', 'Use current request uri as base link instead of related page'];
+$GLOBALS['TL_LANG']['tl_content']['hofff_toc_nav_tpl']           = ['Navigation template', 'Template of the navigation list itself. Choose "hofff_content_nav_foldable" to make the sub levels foldable.'];
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_column']     = 'Article in column';
 $GLOBALS['TL_LANG']['tl_content']['hofff_toc_source_page']       = 'Article in page';
 

--- a/src/Resources/contao/templates/hofff_content_nav_foldable.html5
+++ b/src/Resources/contao/templates/hofff_content_nav_foldable.html5
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Foldable variant of hofff_content_nav_default.
+ *
+ * The sub levels are rendered expanded on purpose. The toggle buttons are added and the sub levels
+ * are collapsed by foldable.js, so that the whole navigation stays usable without JavaScript.
+ */
+?>
+<ul class="level_<?= $this->level ?>"<?php if ($this->level === 1): ?> data-toc-foldable data-toc-expand="<?= \Contao\StringUtil::specialchars($this->expandLabel) ?>" data-toc-collapse="<?= \Contao\StringUtil::specialchars($this->collapseLabel) ?>"<?php endif; ?>>
+    <?php foreach ($this->items as $item): ?>
+        <li class="level_<?= $this->level ?><?php if ($item['class']): ?> <?= $item['class']; endif; ?>"<?php if (! empty($item['anchor'])): ?> data-toc-id="<?= \Contao\StringUtil::specialchars($item['anchor']) ?>"<?php endif; ?>><a href="<?= $item['href'] ?>"><?= $item['title'] ?></a><?= $item['subitems'] ?? '' ?></li>
+    <?php endforeach; ?>
+</ul>

--- a/src/Resources/public/foldable.css
+++ b/src/Resources/public/foldable.css
@@ -1,0 +1,77 @@
+/*
+ * Foldable content navigation.
+ *
+ * Deliberately minimal and scoped to the foldable navigation, so that the surrounding theme keeps
+ * control over colours, fonts and list markers. The caret inherits its colour and size.
+ */
+
+/* Indent the sub levels. Relative to the font size, so that it scales with the theme. */
+[data-toc-foldable] ul {
+    opacity: 1;
+    padding-left: 1.25em;
+    transition:
+        opacity 0.18s ease-out,
+        translate 0.18s ease-out,
+        display 0.18s allow-discrete;
+    translate: 0 0;
+}
+
+/*
+ * The sub levels are collapsed via the hidden attribute. Themes frequently set a display value on
+ * lists, which would win over the browser default for [hidden], hence the explicit rule.
+ *
+ * Transitioning display requires allow-discrete above, so that the sub level stays rendered while
+ * fading out. Browsers not supporting it simply snap, which is a fair fallback.
+ */
+[data-toc-foldable] ul[hidden] {
+    display: none;
+    opacity: 0;
+    translate: 0 -0.25em;
+}
+
+/* The state a sub level starts from when it gets displayed again */
+@starting-style {
+    [data-toc-foldable] ul {
+        opacity: 0;
+        translate: 0 -0.25em;
+    }
+}
+
+.toc-toggle {
+    background: none;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    line-height: 1;
+    margin-left: 0.25em;
+    padding: 0.25em 0.4em;
+    vertical-align: text-bottom;
+}
+
+.toc-toggle::before {
+    border-bottom: 2px solid currentColor;
+    border-right: 2px solid currentColor;
+    content: '';
+    display: inline-block;
+    height: 0.45em;
+    transform: rotate(45deg) translate(-0.1em, -0.1em);
+    transition: transform 0.15s ease-in-out;
+    width: 0.45em;
+}
+
+.toc-toggle[aria-expanded='true']::before {
+    transform: rotate(-135deg) translate(-0.15em, -0.15em);
+}
+
+.toc-toggle:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    [data-toc-foldable] ul,
+    .toc-toggle::before {
+        transition: none;
+    }
+}

--- a/src/Resources/public/foldable.js
+++ b/src/Resources/public/foldable.js
@@ -1,0 +1,159 @@
+/*
+ * Foldable content navigation.
+ *
+ * The navigation is rendered expanded, so that it stays usable without JavaScript. This script adds
+ * the toggle buttons, collapses the sub levels and expands the ancestors of the anchor being linked.
+ */
+(function () {
+    'use strict';
+
+    var idCounter = 0;
+
+    function subList(item) {
+        for (var i = 0; i < item.children.length; i++) {
+            if (item.children[i].tagName === 'UL') {
+                return item.children[i];
+            }
+        }
+
+        return null;
+    }
+
+    function toggleButton(item) {
+        for (var i = 0; i < item.children.length; i++) {
+            if (item.children[i].classList.contains('toc-toggle')) {
+                return item.children[i];
+            }
+        }
+
+        return null;
+    }
+
+    function itemByAnchor(root, anchor) {
+        var items = root.querySelectorAll('[data-toc-id]');
+
+        for (var i = 0; i < items.length; i++) {
+            if (items[i].getAttribute('data-toc-id') === anchor) {
+                return items[i];
+            }
+        }
+
+        return null;
+    }
+
+    function setExpanded(button, expanded) {
+        var list = document.getElementById(button.getAttribute('aria-controls'));
+
+        button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        button.setAttribute(
+            'aria-label',
+            (expanded ? button.dataset.labelCollapse : button.dataset.labelExpand)
+        );
+
+        if (list) {
+            list.hidden = !expanded;
+        }
+
+        button.parentNode.classList.toggle('toc-expanded', expanded);
+    }
+
+    function build(root) {
+        if (root.hasAttribute('data-toc-ready')) {
+            return;
+        }
+
+        root.setAttribute('data-toc-ready', '');
+
+        var expandLabel = root.getAttribute('data-toc-expand') || 'Show sub items of %s';
+        var collapseLabel = root.getAttribute('data-toc-collapse') || 'Hide sub items of %s';
+        var items = root.querySelectorAll('li');
+
+        Array.prototype.forEach.call(items, function (item) {
+            var list = subList(item);
+
+            if (!list) {
+                return;
+            }
+
+            var link = item.querySelector('a');
+            var title = link ? link.textContent.trim() : '';
+
+            if (!list.id) {
+                list.id = 'toc-sub-' + ++idCounter;
+            }
+
+            var button = document.createElement('button');
+
+            button.type = 'button';
+            button.className = 'toc-toggle';
+            button.setAttribute('aria-controls', list.id);
+            button.dataset.labelExpand = expandLabel.replace('%s', title);
+            button.dataset.labelCollapse = collapseLabel.replace('%s', title);
+
+            button.addEventListener('click', function () {
+                setExpanded(button, button.getAttribute('aria-expanded') !== 'true');
+            });
+
+            item.insertBefore(button, list);
+            item.classList.add('toc-has-children');
+
+            setExpanded(button, false);
+        });
+    }
+
+    function reveal(root) {
+        var anchor = window.location.hash.slice(1);
+
+        if (!anchor) {
+            return;
+        }
+
+        var item = itemByAnchor(root, anchor);
+
+        if (!item) {
+            return;
+        }
+
+        var current = root.querySelector('.toc-current');
+
+        if (current) {
+            current.classList.remove('toc-current');
+        }
+
+        item.classList.add('toc-current');
+
+        // Expand every ancestor, so that the linked item becomes visible
+        var node = item.parentNode;
+
+        while (node && node !== root.parentNode) {
+            if (node.tagName === 'LI') {
+                var button = toggleButton(node);
+
+                if (button) {
+                    setExpanded(button, true);
+                }
+            }
+
+            node = node.parentNode;
+        }
+    }
+
+    function init() {
+        var roots = document.querySelectorAll('[data-toc-foldable]');
+
+        Array.prototype.forEach.call(roots, function (root) {
+            build(root);
+            reveal(root);
+
+            window.addEventListener('hashchange', function () {
+                reveal(root);
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
Adds the template hofff_content_nav_foldable and a field to select the navigation template, which was hardcoded before. Entries with children get a toggle button with aria-expanded, aria-controls and aria-label, usable with mouse and keyboard.

The list is rendered expanded and collapsed by the script afterwards, so it stays usable without JavaScript. An anchor in the URL expands its ancestors, matched via the new data-toc-id.

First public assets in this bundle, so assets:install runs once on update.

Heads-up: this overlaps with #39. Both branches merge into master cleanly on their own, but not with each other — ContentNavigationBuilder::collect() and the two tl_content language files each gain a line from both sides. Whichever one lands first, I will rebase the other; the conflicts are purely additive.